### PR TITLE
Authenticated route /projects

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
   <properties>
     <apache.rat.plugin.version>0.13</apache.rat.plugin.version>
     <bc.version>3.0.1</bc.version>
-    <com.capitalone.dashboard.core.version>3.1.9</com.capitalone.dashboard.core.version>
+    <com.capitalone.dashboard.core.version>3.1.11</com.capitalone.dashboard.core.version>
     <commons.io.version>2.4</commons.io.version>
     <commons.lang.version>3.8.1</commons.lang.version>
     <coveralls.maven.plugin.version>4.3.0</coveralls.maven.plugin.version>

--- a/src/main/java/com/capitalone/dashboard/collector/DefaultSonar56Client.java
+++ b/src/main/java/com/capitalone/dashboard/collector/DefaultSonar56Client.java
@@ -27,7 +27,7 @@ public class DefaultSonar56Client extends DefaultSonarClient {
     }
 
     @Override
-    public List<SonarProject> getProjects(String instanceUrl) {
+    public List<SonarProject> getProjects(String instanceUrl,String token) {
         List<SonarProject> projects = new ArrayList<>();
         String url = instanceUrl + URL_PROJECTS;
         try {

--- a/src/main/java/com/capitalone/dashboard/collector/DefaultSonar6Client.java
+++ b/src/main/java/com/capitalone/dashboard/collector/DefaultSonar6Client.java
@@ -7,6 +7,7 @@ import com.capitalone.dashboard.model.CodeQualityMetric;
 import com.capitalone.dashboard.model.CodeQualityMetricStatus;
 import com.capitalone.dashboard.model.CodeQualityType;
 import com.capitalone.dashboard.model.SonarProject;
+import com.capitalone.dashboard.model.UserInfo;
 import com.capitalone.dashboard.util.SonarDashboardUrl;
 import com.capitalone.dashboard.util.Supplier;
 import org.apache.commons.codec.binary.Base64;
@@ -32,12 +33,13 @@ import java.nio.charset.Charset;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 @Component
 public class DefaultSonar6Client implements SonarClient {
     private static final Log LOG = LogFactory.getLog(DefaultSonar6Client.class);
-
     private static final String URL_RESOURCES = "/api/components/search?qualifiers=TRK&ps=500";
+    private static final String URL_RESOURCES_AUTHENTICATED = "/api/projects/search?ps=500";
     private static final String URL_RESOURCE_DETAILS = "/api/measures/component?format=json&componentId=%s&metricKeys=%s&includealerts=true";
     private static final String URL_PROJECT_ANALYSES = "/api/project_analyses/search?project=%s";
     private static final String URL_QUALITY_PROFILES = "/api/qualityprofiles/search";
@@ -69,18 +71,23 @@ public class DefaultSonar6Client implements SonarClient {
 
     @Autowired
     public DefaultSonar6Client(RestClient restClient, SonarSettings settings) {
-        this.userInfo = settings.getUsername()==null?null:new RestUserInfo(settings.getUsername(), settings.getPassword());
+        this.userInfo = new RestUserInfo(settings.getUsername(), settings.getPassword());
         this.restClient = restClient;
     }
 
     @Override
-    public List<SonarProject> getProjects(String instanceUrl) {
+    public List<SonarProject> getProjects(String instanceUrl,String token) {
         List<SonarProject> projects = new ArrayList<>();
-        String url = instanceUrl + URL_RESOURCES;
-
+        String url = "";
+        // take authenticated route
+        if(Objects.nonNull(token)){
+            url = instanceUrl +  URL_RESOURCES_AUTHENTICATED;
+        }else{
+            url = instanceUrl + URL_RESOURCES;
+        }
+        userInfo.setToken(token);
         try {
-            String key = "components";
-            JSONArray jsonArray = getProjects(url, key);
+            JSONArray jsonArray = getProjects(url);
             for (Object obj : jsonArray) {
                 JSONObject prjData = (JSONObject) obj;
 
@@ -100,7 +107,8 @@ public class DefaultSonar6Client implements SonarClient {
         return projects;
     }
 
-    private JSONArray getProjects(String url, String key) throws ParseException {
+    private JSONArray getProjects(String url) throws ParseException {
+        String key = "components";
         Long totalRecords = getTotalCount(parseJsonObject(url, "paging"));
         int pages = (int) Math.ceil((double)totalRecords / PAGE_SIZE);
         JSONArray jsonArray = new JSONArray();
@@ -114,14 +122,24 @@ public class DefaultSonar6Client implements SonarClient {
     }
 
     private JSONArray getProjects(String url, String key, int pages, JSONArray jsonArray) throws ParseException {
+        if(Objects.isNull(userInfo.getToken())){
+            pagingUnAuthenticated(url, key, pages, jsonArray);
+        }else{
+            for (int start=1;start<=pages;start++){
+                getProjects(url, key, jsonArray, start);
+            }
+        }
+        return  jsonArray;
+    }
+
+    private void pagingUnAuthenticated(String url, String key, int pages, JSONArray jsonArray) throws ParseException {
         int maxPages = 20;
         if(pages <= maxPages) {
             maxPages = pages;
         }
-       for (int start=1;start<=maxPages;start++){
+        for (int start=1;start<=maxPages;start++){
             getProjects(url, key, jsonArray, start);
         }
-        return  jsonArray;
     }
 
     private void getProjects(String url, String key, JSONArray jsonArray, int pageNumber) throws ParseException {
@@ -135,7 +153,7 @@ public class DefaultSonar6Client implements SonarClient {
                 project.getInstanceUrl() + URL_RESOURCE_DETAILS, project.getProjectId(), metrics);
 
         try {
-            ResponseEntity<String> response = restClient.makeRestCallGet(url, this.userInfo);
+            ResponseEntity<String> response = restClient.makeRestCallGet(url,setHeaders(userInfo) );
             JSONParser jsonParser = new JSONParser();
             JSONObject jsonObject = (JSONObject) jsonParser.parse(response.getBody());
             String key = "component";
@@ -258,7 +276,7 @@ public class DefaultSonar6Client implements SonarClient {
     }
 
     private JSONObject getResponse(String url) throws ParseException {
-        ResponseEntity<String> response = restClient.makeRestCallGet(url, this.userInfo);
+        ResponseEntity<String> response = restClient.makeRestCallGet(url, setHeaders(userInfo));
         JSONParser jsonParser = new JSONParser();
         JSONObject jsonObject = (JSONObject) jsonParser.parse(response.getBody());
         LOG.debug(url);
@@ -369,5 +387,40 @@ public class DefaultSonar6Client implements SonarClient {
     private Long getTotalCount(JSONObject pagingObject) {
         return (Long) pagingObject.get("total");
     }
+
+    private HttpHeaders createHeaders(String username, String password){
+        HttpHeaders headers = new HttpHeaders();
+        if (username != null && !username.isEmpty()) {
+            String auth = username + ":" + (password == null ? "" : password);
+            byte[] encodedAuth = Base64.encodeBase64(
+                    auth.getBytes(Charset.forName("US-ASCII"))
+            );
+            String authHeader = "Basic " + new String(encodedAuth);
+            headers.set("Authorization", authHeader);
+        }
+        return headers;
+    }
+
+    private HttpHeaders createHeaders(String token) {
+        String auth = token.trim();
+        auth = auth+":";
+        byte[] encodedAuth = Base64.encodeBase64(
+                auth.getBytes(Charset.forName("US-ASCII"))
+        );
+        String authHeader = "Basic " + new String(encodedAuth);
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("Authorization", authHeader);
+        return headers;
+    }
+
+    private HttpHeaders setHeaders(RestUserInfo userInfo){
+        if(StringUtils.isNotBlank(userInfo.getUserId())&& StringUtils.isNotBlank(userInfo.getPassCode())){
+            return createHeaders(userInfo.getUserId(),userInfo.getPassCode());
+        }else if(StringUtils.isNotBlank(userInfo.getToken())){
+            return createHeaders(userInfo.getToken());
+        }
+        return null;
+    }
+
 
 }

--- a/src/main/java/com/capitalone/dashboard/collector/DefaultSonarClient.java
+++ b/src/main/java/com/capitalone/dashboard/collector/DefaultSonarClient.java
@@ -63,7 +63,7 @@ public class DefaultSonarClient implements SonarClient {
     }
 
     @Override
-    public List<SonarProject> getProjects(String instanceUrl) {
+    public List<SonarProject> getProjects(String instanceUrl,String token) {
         List<SonarProject> projects = new ArrayList<>();
         String url = instanceUrl + URL_RESOURCES;
 

--- a/src/main/java/com/capitalone/dashboard/collector/SonarClient.java
+++ b/src/main/java/com/capitalone/dashboard/collector/SonarClient.java
@@ -10,7 +10,7 @@ import org.json.simple.parser.ParseException;
 
 public interface SonarClient {
 
-    List<SonarProject> getProjects(String instanceUrl);
+    List<SonarProject> getProjects(String instanceUrl,String token);
     CodeQuality currentCodeQuality(SonarProject project, String metrics);
     JSONArray getQualityProfiles(String instanceUrl) throws ParseException;
     List<String> retrieveProfileAndProjectAssociation(String instanceUrl,String qualityProfile) throws ParseException;

--- a/src/main/java/com/capitalone/dashboard/collector/SonarCollectorTask.java
+++ b/src/main/java/com/capitalone/dashboard/collector/SonarCollectorTask.java
@@ -98,10 +98,11 @@ public class SonarCollectorTask extends CollectorTask<SonarCollector> {
                 String instanceUrl = collector.getSonarServers().get(i);
                 Double version = collector.getSonarVersions().get(i);
                 String metrics = collector.getSonarMetrics().get(i);
+                String token = getToken(sonarSettings.getTokens(),i);
 
                 logBanner(instanceUrl);
                 SonarClient sonarClient = sonarClientSelector.getSonarClient(version);
-                List<SonarProject> projects = sonarClient.getProjects(instanceUrl);
+                List<SonarProject> projects = sonarClient.getProjects(instanceUrl,token);
                 latestProjects.addAll(projects);
 
                 int projSize = ((CollectionUtils.isEmpty(projects)) ? 0 : projects.size());
@@ -126,6 +127,14 @@ public class SonarCollectorTask extends CollectorTask<SonarCollector> {
         deleteUnwantedJobs(latestProjects, existingProjects, collector);
     }
 
+
+    private String getToken(List<String> tokens,int index){
+        if(CollectionUtils.isEmpty(tokens)) return null;
+        if (CollectionUtils.isNotEmpty(tokens)){
+            return tokens.get(index);
+        }
+        return null;
+    }
 	/**
 	 * Clean up unused sonar collector items
 	 *

--- a/src/main/java/com/capitalone/dashboard/collector/SonarSettings.java
+++ b/src/main/java/com/capitalone/dashboard/collector/SonarSettings.java
@@ -18,6 +18,7 @@ public class SonarSettings {
     private List<Double> versions;
     private List<String> metrics;
     private List<String> niceNames;
+    private List<String> tokens;
 
     public String getCron() {
         return cron;
@@ -73,6 +74,14 @@ public class SonarSettings {
 
     public void setNiceNames(List<String> niceNames) {
         this.niceNames = niceNames;
+    }
+
+    public List<String> getTokens() {
+        return tokens;
+    }
+
+    public void setTokens(List<String> tokens) {
+        this.tokens = tokens;
     }
 
 }

--- a/src/test/java/com/capitalone/dashboard/collector/DefaultSonar6ClientTest.java
+++ b/src/test/java/com/capitalone/dashboard/collector/DefaultSonar6ClientTest.java
@@ -58,7 +58,7 @@ public class DefaultSonar6ClientTest {
         String projectJson = getJson("sonar6projects.json");
         String projectsUrl = SONAR_URL + URL_RESOURCES;
         doReturn(new ResponseEntity<>(projectJson, HttpStatus.OK)).when(rest).exchange(eq(projectsUrl), eq(HttpMethod.GET), Matchers.any(HttpEntity.class), eq(String.class));
-        List<SonarProject> projects = defaultSonar6Client.getProjects(SONAR_URL);
+        List<SonarProject> projects = defaultSonar6Client.getProjects(SONAR_URL,null);
         assertThat(projects.size(), is(2));
         assertThat(projects.get(0).getProjectName(), is("com.capitalone.test:TestProject"));
         assertThat(projects.get(1).getProjectName(), is("com.capitalone.test:AnotherTestProject"));
@@ -83,7 +83,7 @@ public class DefaultSonar6ClientTest {
         doReturn(new ResponseEntity<>(projectJson1500, HttpStatus.OK)).when(rest).exchange(eq(projectsUrl3), eq(HttpMethod.GET), Matchers.any(HttpEntity.class), eq(String.class));
         doReturn(new ResponseEntity<>(projectJson2000, HttpStatus.OK)).when(rest).exchange(eq(projectsUrl4), eq(HttpMethod.GET), Matchers.any(HttpEntity.class), eq(String.class));
 
-        List<SonarProject> projects = defaultSonar6Client.getProjects(SONAR_URL);
+        List<SonarProject> projects = defaultSonar6Client.getProjects(SONAR_URL,null);
         assertThat(projects.size(), is(2000));
     }
 


### PR DESCRIPTION
Added authenticated route to fetch all projects from Sonar with /projects. If token is not passed via properties, collector will take unauthenticated route and follow the original process. 
