### PR TITLE
Fix Sonar collector refresh logic

### DIFF
--- a/src/main/java/com/capitalone/dashboard/controller/SonarController.java
+++ b/src/main/java/com/capitalone/dashboard/controller/SonarController.java
@@ -9,6 +9,7 @@ import com.capitalone.dashboard.repository.CollectorRepository;
 import com.capitalone.dashboard.repository.SonarProjectRepository;
 import com.capitalone.dashboard.util.SonarCollectorUtil;
 import org.apache.commons.collections4.CollectionUtils;
+import org.bson.types.ObjectId;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.HttpHeaders;
@@ -19,9 +20,11 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import javax.validation.Valid;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
+import java.util.stream.Collectors;
 
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 import static org.springframework.web.bind.annotation.RequestMethod.GET;
@@ -34,13 +37,6 @@ public class SonarController {
     private final CodeQualityRepository codeQualityRepository;
     private final CollectorRepository collectorRepository;
     private SonarClientSelector sonarClientSelector;
-
-
-    private String instanceUrl;
-    private String projectName;
-    private String projectKey;
-    private Collector collector;
-    private SonarClient sonarClient;
 
     @Autowired
     public SonarController(SonarProjectRepository sonarProjectRepository,
@@ -56,16 +52,16 @@ public class SonarController {
     @RequestMapping(value = "/refresh", method = GET, produces = APPLICATION_JSON_VALUE)
     public ResponseEntity<String> refresh(@Valid String projectName, @Valid String projectKey, @Valid String instanceUrl) {
 
-        gatherParams(projectName, projectKey, instanceUrl);
         if (Objects.nonNull(instanceUrl)) {
-            this.sonarClient = this.sonarClientSelector.getSonarClient(this.sonarClientSelector.getSonarVersion(instanceUrl));
-            this.collector = collectorRepository.findByName("Sonar");
+            SonarClient sonarClient = this.sonarClientSelector.getSonarClient(this.sonarClientSelector.getSonarVersion(instanceUrl));
+            Collector collector = collectorRepository.findByName("Sonar");
 
             SonarProject projectToRefresh;
-            if (Objects.nonNull(this.collector)) {
-                if ((Objects.nonNull(projectName) && Objects.nonNull(projectToRefresh = getExistingProject()))
-                || (Objects.nonNull(projectKey) && Objects.nonNull(projectToRefresh = createNewProjectIfNotExists()))) {
-                    SonarCollectorUtil.updateCodeQualityData(this.collector, this.sonarClient, projectToRefresh);
+            if (Objects.nonNull(collector)) {
+                if ((Objects.nonNull(projectName) &&
+                        Objects.nonNull(projectToRefresh = getExistingProject(collector.getId(),
+                                instanceUrl, projectName, projectKey, sonarClient)))) {
+                    SonarCollectorUtil.updateCodeQualityData(collector, sonarClient, projectToRefresh);
                     return sendResponse("successfully refreshed sonar project");
                 }
                 return sendResponse("unable to refresh sonar project");
@@ -75,35 +71,30 @@ public class SonarController {
         return sendResponse("sonar instance url is invalid");
     }
 
-    private void gatherParams(String projectName, String projectKey, String instanceUrl) {
-        this.projectName = projectName;
-        this.projectKey = projectKey;
-        this.instanceUrl = instanceUrl;
-    }
-
     private ResponseEntity<String> sendResponse(String message) {
         HttpHeaders httpHeaders = new HttpHeaders();
         httpHeaders.setContentType(MediaType.APPLICATION_JSON);
         return new ResponseEntity<>(message, httpHeaders, HttpStatus.OK);
     }
 
-    private SonarProject createNewProjectIfNotExists() {
-        SonarProject project = null;
-        if (Objects.nonNull(this.projectKey)) {
-            SonarProject newProject = this.sonarClient.getProject(this.projectKey, this.instanceUrl);
-            if (Objects.nonNull(newProject)) {
-                SonarProject existingProject = sonarProjectRepository.findSonarProject(this.collector.getId(),
-                        newProject.getInstanceUrl(), newProject.getProjectId());
-                project = Objects.nonNull(existingProject) ? existingProject : newProject;
+    private SonarProject getExistingProject(ObjectId collectorId, String instanceUrl, String projectName,
+                                            String projectKey, SonarClient sonarClient) {
+        if (Objects.nonNull(projectKey)) {
+            SonarProject project = sonarClient.getProject(projectKey, instanceUrl);
+            if (Objects.nonNull(project)) {
+                List<SonarProject> sonarProjects = sonarProjectRepository.
+                        findSonarProjectsByProjectName(collectorId, instanceUrl, projectName);
+                if (CollectionUtils.isNotEmpty(sonarProjects)) {
+                    sonarProjects = sonarProjects.stream().filter(p -> p.getProjectId()==null || project.getProjectId().equals(p.getProjectId())).collect(Collectors.toList());
+                }
+                if (CollectionUtils.isNotEmpty(sonarProjects)) {
+                    Collections.sort(sonarProjects, Comparator.comparing(SonarProject::getLastUpdated).reversed());
+                    SonarProject existingProject = sonarProjects.get(0);
+                    existingProject.setProjectId(project.getProjectId());
+                    return existingProject;
+                }
             }
         }
-        return project;
-    }
-
-    private SonarProject getExistingProject() {
-        List<SonarProject> sonarProjects = sonarProjectRepository.
-                findSonarProjectsByProjectName(this.collector.getId(), this.instanceUrl, this.projectName);
-        return CollectionUtils.isNotEmpty(sonarProjects) ?
-                sonarProjects.stream().sorted(Comparator.comparing(SonarProject::getLastUpdated).reversed()).findFirst().get() : null;
+        return null;
     }
 }


### PR DESCRIPTION
Sonar collector refresh logic did not work for collector items just created, before any scheduled collection activities.